### PR TITLE
Initialize Scan-to-Support Next.js app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
-# Non-Profit Scan
+# Scan-to-Support
 
-Testing 
+A simple Next.js app that displays a daily rotating nonprofit pulled from a local data file.
+
+## Development
+
+1. Install dependencies (requires internet access):
+
+```bash
+npm install
+```
+
+2. Generate QR codes whenever `data/causes.js` changes:
+
+```bash
+node generate_qrs.js
+```
+
+3. Run the development server:
+
+```bash
+npm run dev
+```
+
+The app shows the cause that matches today's date or a placeholder message if none is found.
+
+QR images are stored in `/public/qr/` and named after each nonprofit using a slug of its name (e.g. `evergreen-fund.png`).

--- a/data/causes.js
+++ b/data/causes.js
@@ -1,0 +1,20 @@
+export const causes = [
+  {
+    date: "2025-06-27",
+    name: "Evergreen Fund",
+    description: "Free trauma therapy for youth.",
+    external_link: "https://app.endaoment.org/org/822364972"
+  },
+  {
+    date: "2025-06-28",
+    name: "Clean Water Initiative",
+    description: "Bringing clean water to communities in need.",
+    external_link: "https://app.endaoment.org/org/123456789"
+  },
+  {
+    date: "2025-06-29",
+    name: "Education for All",
+    description: "Scholarships for underprivileged students.",
+    external_link: "https://app.endaoment.org/org/987654321"
+  }
+];

--- a/generate_qrs.js
+++ b/generate_qrs.js
@@ -1,0 +1,31 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import QRCode from 'qrcode';
+import { causes } from './data/causes.js';
+
+async function ensureDir(dir) {
+  try {
+    await fs.mkdir(dir, { recursive: true });
+  } catch (err) {
+    console.error('Error creating directory', err);
+  }
+}
+
+async function generate() {
+  const outDir = path.join(process.cwd(), 'public', 'qr');
+  await ensureDir(outDir);
+
+  for (const cause of causes) {
+    const slug = cause.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    const fileName = `${slug}.png`;
+    const outPath = path.join(outDir, fileName);
+    try {
+      await QRCode.toFile(outPath, cause.external_link);
+      console.log(`Generated ${outPath}`);
+    } catch (err) {
+      console.error(`Failed to generate QR for ${cause.name}`, err);
+    }
+  }
+}
+
+generate();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "scan-to-support",
+  "version": "1.0.0",
+  "description": "Scan-to-Support Next.js app displaying rotating nonprofits",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "qrcode": "latest"
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,39 @@
+import { causes } from '../data/causes';
+import { useEffect, useState } from 'react';
+
+export default function Home() {
+  const [cause, setCause] = useState(null);
+
+  useEffect(() => {
+    const today = new Date().toISOString().split('T')[0];
+    const match = causes.find(c => c.date === today);
+    if (match) {
+      setCause(match);
+    }
+  }, []);
+
+  if (!cause) {
+    return (
+      <main style={{padding: '1rem', fontFamily: 'Arial', textAlign: 'center'}}>
+        <h1>Cause coming soon</h1>
+        <p>Please check back later.</p>
+      </main>
+    );
+  }
+
+  const slug = cause.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+  const qrPath = `/qr/${slug}.png`
+
+  return (
+    <main style={{maxWidth: '600px', margin: 'auto', padding: '1rem', fontFamily: 'Arial', textAlign: 'center'}}>
+      <h1>{cause.name}</h1>
+      <p>{cause.description}</p>
+      <img src={qrPath} alt={`QR for ${cause.name}`} style={{width: '200px', height: '200px'}} />
+      <div style={{marginTop: '1rem'}}>
+        <a href={cause.external_link} target="_blank" rel="noopener noreferrer" style={{backgroundColor: '#0070f3', color: '#fff', padding: '0.5rem 1rem', borderRadius: '4px', textDecoration: 'none'}}>
+          Donate via Endaoment
+        </a>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- initialize Next.js package config
- add sample causes data
- add daily rotating homepage
- create QR-code generator script
- document setup steps
- generate QR codes using slug-based filenames

## Testing
- `npm test`
- `node generate_qrs.js` *(fails: Cannot find package 'qrcode')*

------
https://chatgpt.com/codex/tasks/task_e_685ee622517483329165c5563296fb49